### PR TITLE
Add indent argument for writing pretty json

### DIFF
--- a/datakit/utils.py
+++ b/datakit/utils.py
@@ -29,9 +29,9 @@ def read_json(path):
         return json.load(fh)
 
 
-def write_json(path, data):
+def write_json(path, data, indent=4):
     with open(path, 'w') as fh:
-        json.dump(data, fh)
+        json.dump(data, fh, indent=indent)
 
 
 def dist_for_obj(obj):


### PR DESCRIPTION
Add an `indent` keyword argument to the `write_json` utility function
and give it a default value of `4` to pretty-print json files by
default. This should make json config files more human-readable and
hand-editable.

This is a proposed addition to address [this enhancement][issue].

[issue]: https://github.com/associatedpress/datakit-core/issues/17